### PR TITLE
Fix version for `configparser`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 BeautifulSoup4==4.3.2
-configparser==3.3.0r2
+configparser==3.3.0.post2
 docopt==0.6.1
 nose==1.3.0
 prettytable==0.7.2

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         'BeautifulSoup4 >= 4.3.2',
-        'configparser == 3.3.0r2',
+        'configparser == 3.3.0.post2',
         'docopt >= 0.6.1',
         'prettytable >= 0.7.2',
         'requests >= 2.2.1'


### PR DESCRIPTION
When installing clippercard with pip, I get the following error. By changing the configparser version from `3.3.0r2` to `3.3.0.post2` pip install works correctly.

```
$ pip install clippercard
Collecting clippercard
  Using cached clippercard-0.3.0.tar.gz
Collecting BeautifulSoup4>=4.3.2 (from clippercard)
  Using cached beautifulsoup4-4.3.2.tar.gz
Collecting configparser==3.3.0r2 (from clippercard)
  Could not find a version that satisfies the requirement configparser==3.3.0r2 (from clippercard) (from versions: 3.2.0.post1, 3.2.0.post2, 3.2.0.post3, 3.3.0.post1, 3.3.0.post2, 3.5.0b1, 3.5.0b2)
  Some externally hosted files were ignored as access to them may be unreliable (use --allow-external to allow).
  No distributions matching the version for configparser==3.3.0r2 (from clippercard)
```
You can try install it by executing the following command: 
```
pip install http://github.com/thejsj/clippercard/archive/v0.0.1.tar.gz
```

There might be a better solution to this problem. If there is, let me know.