### PR TITLE
[codex] redact alternate phone in summary output

### DIFF
--- a/clippercard/porcelain.py
+++ b/clippercard/porcelain.py
@@ -51,7 +51,7 @@ def _redact_private_info(label, value):
             return local[0] + "***@" + domain
         case "mailing_address":
             return "***"
-        case "phone":
+        case "phone" | "alt_phone":
             re_match = re.match(r"(\+?\d{1,3})?([-.\s]?)[0-9-.\s]+(\d{2}-?\d{2})", value)
             if re_match:
                 groups = re_match.groups()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "clippercard"
-version = "202606.1.1"
+version = "202606.1.2"
 description = "Unofficial Python API for Clipper Card (transportation pass used in the SF Bay Area)"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -74,5 +74,16 @@ def test_tabular_output_renders_profile_and_cards_as_ascii_tables_without_privat
     )
 
 
+def test_tabular_output_redacts_alternate_phone_without_private_info():
+    profile = namedtuple("Profile", "alt_phone")(
+        alt_phone="+1 510-555-0199",
+    )
+
+    output = tabular_output(profile, None, show_private=False)
+
+    assert "+1 510-555-0199" not in output
+    assert "+1 ***-***-0199" in output
+
+
 def test_tabular_output_reports_missing_cards():
     assert tabular_output(None, []) == "No cards registered"


### PR DESCRIPTION
## Summary

- redact alt_phone values when summary output hides private information
- add a regression test using a reserved 555 fixture number

## Validation

- env UV_CACHE_DIR=/private/tmp/clippercard-uv-cache uv run pytest tests/test_porcelain.py