### PR TITLE
[codex] add summary json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,46 @@ $ clippercard summary --account=other
 Non-default accounts keep separate saved login cookies in account-specific files such as
 `~/.config/clippercard/auth.other.cookies`.
 
+For scripts and agents, request structured JSON instead of the default table output:
+
+```sh
+$ clippercard summary --output json
+{
+  "profile": {
+    "name": "Go*** Ga*** Ri***",
+    "email": "g***@example.com"
+  },
+  "cards": [
+    {
+      "serial_number": "******4134",
+      "nickname": "Primary, card ending in 4134",
+      "type": "ADULT",
+      "status": "Active",
+      "products": [
+        {
+          "name": "Cash Value",
+          "value": "$195.00"
+        }
+      ],
+      "features": [
+        {
+          "name": "Reload",
+          "value": "$255 - Autoload"
+        }
+      ]
+    }
+  ]
+}
+```
+
+When stdout is piped, `summary` defaults to JSON for Unix tooling:
+
+```sh
+$ clippercard summary | jq .
+```
+
+Use `--show-private` with either output format to include unredacted profile and card details.
+
 # More examples
 
 If you have a transit pass that isn't recognized by this tool, you can privately share a copy of your account page `view-source:` with the maintainer.

--- a/clippercard/main.py
+++ b/clippercard/main.py
@@ -102,6 +102,12 @@ def _build_parser():
     summary.add_argument(
         "--show-private", action="store_true", help="Show private information like card numbers (use with caution)"
     )
+    summary.add_argument(
+        "--output",
+        choices=("table", "json"),
+        default=None,
+        help="Output format (default: table when interactive, json when piped)",
+    )
 
     auth_group = summary.add_argument_group("authentication")
     auth_group.add_argument(
@@ -140,13 +146,25 @@ def main():
             cookie_jar_path=_cookie_jar_path_for_account(args.account),
         )
         if args.command == "summary":
+            output = args.output or ("table" if sys.stdout.isatty() else "json")
             if session.reused_cookies:
-                print(f"Reusing saved cookies from {session.cookie_jar_path}")
-            print(
-                clippercard.porcelain.tabular_output(
-                    session.profile_info, session.cards, show_private=args.show_private
+                cookie_message = f"Reusing saved cookies from {session.cookie_jar_path}"
+                if output == "json":
+                    print(cookie_message, file=sys.stderr)
+                else:
+                    print(cookie_message)
+            if output == "json":
+                print(
+                    clippercard.porcelain.summary_json_output(
+                        session.profile_info, session.cards, show_private=args.show_private
+                    )
                 )
-            )
+            else:
+                print(
+                    clippercard.porcelain.tabular_output(
+                        session.profile_info, session.cards, show_private=args.show_private
+                    )
+                )
     except (clippercard.client.ClipperCardError, ClipperCardCommandError, FileNotFoundError) as e:
         sys.exit(str(e))
 

--- a/clippercard/parser.py
+++ b/clippercard/parser.py
@@ -20,11 +20,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 import collections
-from datetime import datetime
 import itertools
 import json
 import logging
 import re
+from datetime import datetime
 from warnings import deprecated
 
 import bs4

--- a/clippercard/porcelain.py
+++ b/clippercard/porcelain.py
@@ -19,8 +19,9 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
-from io import StringIO
+import json
 import re
+from io import StringIO
 
 from rich import box
 from rich.console import Console
@@ -43,6 +44,8 @@ def _render_table(table):
 
 
 def _redact_private_info(label, value):
+    if value is None:
+        return value
     match label.lower():
         case "name":
             return " ".join([part[:2] + "***" for part in value.split()])
@@ -60,6 +63,58 @@ def _redact_private_info(label, value):
         case "serial_number":
             return ("*" * (len(value) - 4)) + value[-4:]
     return value
+
+
+def _asdict(value):
+    if value is None:
+        return None
+    if hasattr(value, "_asdict"):
+        return value._asdict()
+    if isinstance(value, dict):
+        return value
+    return vars(value)
+
+
+def _product_to_json(product):
+    data = _asdict(product)
+    return {
+        "name": data.get("name"),
+        "value": data.get("value"),
+    }
+
+
+def summary_json_output(user_profile, cards, show_private=False):
+    """
+    Serializes a user profile and its associated cards and products as JSON.
+    """
+    profile = _asdict(user_profile)
+    if profile is not None:
+        profile = {
+            label: (_redact_private_info(label, value) if not show_private else value)
+            for label, value in profile.items()
+            if value not in (None, "")
+        }
+
+    card_items = None
+    if cards is not None:
+        card_items = []
+        for card in cards:
+            card_data = _asdict(card)
+            serial_number = card_data.get("serial_number")
+            if not show_private:
+                serial_number = _redact_private_info("serial_number", serial_number)
+            card_items.append(
+                {
+                    "serial_number": serial_number,
+                    "nickname": card_data.get("nickname"),
+                    "type": card_data.get("type"),
+                    "status": card_data.get("status"),
+                    "products": [_product_to_json(product) for product in card_data.get("products", [])],
+                    "features": [_product_to_json(feature) for feature in card_data.get("features", [])],
+                }
+            )
+
+    return json.dumps({"profile": profile, "cards": card_items}, indent=2)
 
 
 def tabular_output(user_profile, cards, show_private=False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "clippercard"
-version = "202606.1.2"
+version = "202606.2.1"
 description = "Unofficial Python API for Clipper Card (transportation pass used in the SF Bay Area)"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,6 +44,7 @@ def test_summary_uses_account_specific_cookie_jar_path():
         patch("clippercard.main._cookie_jar_path_for_account", return_value=expected_cookie_path) as cookie_path_mock,
         patch("clippercard.main.clippercard.Session", return_value=DummySession()) as session_mock,
         patch("clippercard.main.clippercard.porcelain.tabular_output", return_value="summary output"),
+        patch("clippercard.main.sys.stdout.isatty", return_value=True),
         patch("clippercard.main.print") as print_mock,
     ):
         main.main()
@@ -55,6 +56,77 @@ def test_summary_uses_account_specific_cookie_jar_path():
         cookie_jar_path=expected_cookie_path,
     )
     print_mock.assert_called_once_with("summary output")
+
+
+def test_summary_can_output_json_without_cookie_message_on_stdout(capsys):
+    expected_cookie_path = Path("/tmp/auth.cookies")
+
+    class DummySession:
+        reused_cookies = True
+        cookie_jar_path = expected_cookie_path
+        profile_info = None
+        cards = []
+
+    with (
+        patch.object(sys, "argv", ["clippercard", "summary", "--output", "json"]),
+        patch("clippercard.main._get_client_auth", return_value=("person@example.com", "supersecret")),
+        patch("clippercard.main._cookie_jar_path_for_account", return_value=expected_cookie_path),
+        patch("clippercard.main.clippercard.Session", return_value=DummySession()),
+        patch("clippercard.main.clippercard.porcelain.summary_json_output", return_value='{"cards": []}'),
+    ):
+        main.main()
+
+    output = capsys.readouterr()
+    assert output.out == '{"cards": []}\n'
+    assert output.err == f"Reusing saved cookies from {expected_cookie_path}\n"
+
+
+def test_summary_defaults_to_json_when_stdout_is_piped(capsys):
+    expected_cookie_path = Path("/tmp/auth.cookies")
+
+    class DummySession:
+        reused_cookies = True
+        cookie_jar_path = expected_cookie_path
+        profile_info = None
+        cards = []
+
+    with (
+        patch.object(sys, "argv", ["clippercard", "summary"]),
+        patch("clippercard.main._get_client_auth", return_value=("person@example.com", "supersecret")),
+        patch("clippercard.main._cookie_jar_path_for_account", return_value=expected_cookie_path),
+        patch("clippercard.main.clippercard.Session", return_value=DummySession()),
+        patch("clippercard.main.clippercard.porcelain.summary_json_output", return_value='{"cards": []}'),
+        patch("clippercard.main.sys.stdout.isatty", return_value=False),
+    ):
+        main.main()
+
+    output = capsys.readouterr()
+    assert output.out == '{"cards": []}\n'
+    assert output.err == f"Reusing saved cookies from {expected_cookie_path}\n"
+
+
+def test_summary_output_table_overrides_pipe_detection(capsys):
+    expected_cookie_path = Path("/tmp/auth.cookies")
+
+    class DummySession:
+        reused_cookies = True
+        cookie_jar_path = expected_cookie_path
+        profile_info = None
+        cards = []
+
+    with (
+        patch.object(sys, "argv", ["clippercard", "summary", "--output", "table"]),
+        patch("clippercard.main._get_client_auth", return_value=("person@example.com", "supersecret")),
+        patch("clippercard.main._cookie_jar_path_for_account", return_value=expected_cookie_path),
+        patch("clippercard.main.clippercard.Session", return_value=DummySession()),
+        patch("clippercard.main.clippercard.porcelain.tabular_output", return_value="summary output"),
+        patch("clippercard.main.sys.stdout.isatty", return_value=False),
+    ):
+        main.main()
+
+    output = capsys.readouterr()
+    assert output.out == f"Reusing saved cookies from {expected_cookie_path}\nsummary output\n"
+    assert output.err == ""
 
 
 def test_main_cli_only_exposes_summary_subcommand():

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -1,7 +1,8 @@
+import json
 from collections import namedtuple
 from types import SimpleNamespace
 
-from clippercard.porcelain import tabular_output
+from clippercard.porcelain import summary_json_output, tabular_output
 
 
 def test_tabular_output_renders_profile_and_cards_as_ascii_tables():
@@ -87,3 +88,40 @@ def test_tabular_output_redacts_alternate_phone_without_private_info():
 
 def test_tabular_output_reports_missing_cards():
     assert tabular_output(None, []) == "No cards registered"
+
+
+def test_summary_json_output_renders_profile_and_cards_without_private_info():
+    profile = namedtuple("Profile", "name email alt_phone")(
+        name="Golden Gate Hacker",
+        email="goldengate88@systemfu.com",
+        alt_phone="",
+    )
+    cards = [
+        SimpleNamespace(
+            nickname="Primary, card ending in 4134",
+            serial_number="2021234134",
+            type="ADULT",
+            status="Active",
+            products=[SimpleNamespace(name="Cash Value", value="$195.00")],
+            features=[SimpleNamespace(name="Reload", value="$255 - Autoload")],
+        )
+    ]
+
+    output = json.loads(summary_json_output(profile, cards, show_private=False))
+
+    assert output == {
+        "profile": {
+            "name": "Go*** Ga*** Ha***",
+            "email": "g***@systemfu.com",
+        },
+        "cards": [
+            {
+                "serial_number": "******4134",
+                "nickname": "Primary, card ending in 4134",
+                "type": "ADULT",
+                "status": "Active",
+                "products": [{"name": "Cash Value", "value": "$195.00"}],
+                "features": [{"name": "Reload", "value": "$255 - Autoload"}],
+            }
+        ],
+    }


### PR DESCRIPTION
## What changed

- Added `clippercard summary --output json` for structured summary output.
- Defaults `clippercard summary` to JSON when stdout is piped, so workflows like `clippercard summary | jq .` work without an explicit `--output json`.
- Kept the default interactive table output unchanged, and `--output table` can still force tables in a pipe.
- Redacts private profile/card fields in JSON by default, matching the table output behavior.
- Sends reused-cookie notices to stderr in JSON mode so stdout remains parseable.
- Documented the JSON mode and included tests for formatter output, CLI routing, pipe detection, and explicit table override.
- Included the existing version bump to `202606.2.1` and parser import-order cleanup from the working tree, per `commit all`.

## Why

The CLI previously only emitted human-readable summary tables. Scripts and agents need a stable structured output format that can be parsed without scraping terminal tables, and Unix pipelines should get machine-readable stdout by default.

## Validation

- `uv run pytest tests/test_main.py tests/test_porcelain.py`
- `uv run ruff check clippercard/main.py clippercard/porcelain.py tests/test_main.py tests/test_porcelain.py`
- `just test`
- `just lint`