### PR TITLE
Raise dependency floors and pin CI to uv 0.12.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install uv and Python
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d  # v10.0.0
         with:
-          version: "0.12.4"  # pinned uv: makes uv.lock rendering reproducible
+          version: "0.12.5"  # pinned uv: makes uv.lock rendering reproducible
           python-version: ${{ matrix.python-version }}
           activate-environment: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.11.3,<0.12"]
+requires = ["uv_build>=0.12.5,<0.13"]
 build-backend = "uv_build"
 
 [project]
@@ -24,19 +24,19 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "beautifulsoup4>=4.9.0",
-    "rich>=13.0.0",
-    "requests>=2.25.0,<3.0",
-    "urllib3>=1.26.0",
+    "beautifulsoup4>=4.15.0",
+    "rich>=15.0.0",
+    "requests>=2.34.2,<3.0",
+    "urllib3>=2.7.0",
 ]
 
 [dependency-groups]
 dev = [
-    "pytest>=7.0.0",
-    "ruff>=0.4.0",
-    "build>=1.0.0",
-    "twine>=5.0.0",
-    "nox>=2024.3.2",
+    "pytest>=9.1.1",
+    "ruff>=0.16.3",
+    "build>=1.5.0",
+    "twine>=7.0.0",
+    "nox>=2026.8.17",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -287,19 +287,19 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "beautifulsoup4", specifier = ">=4.9.0" },
-    { name = "requests", specifier = ">=2.25.0,<3.0" },
-    { name = "rich", specifier = ">=13.0.0" },
-    { name = "urllib3", specifier = ">=1.26.0" },
+    { name = "beautifulsoup4", specifier = ">=4.15.0" },
+    { name = "requests", specifier = ">=2.34.2,<3.0" },
+    { name = "rich", specifier = ">=15.0.0" },
+    { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "build", specifier = ">=1.0.0" },
-    { name = "nox", specifier = ">=2024.3.2" },
-    { name = "pytest", specifier = ">=7.0.0" },
-    { name = "ruff", specifier = ">=0.4.0" },
-    { name = "twine", specifier = ">=5.0.0" },
+    { name = "build", specifier = ">=1.5.0" },
+    { name = "nox", specifier = ">=2026.8.17" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.16.3" },
+    { name = "twine", specifier = ">=7.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

The lockfile was already on current PyPI, but declared floors in `pyproject.toml` were years stale (`beautifulsoup4>=4.9`, `urllib3>=1.26`, `uv_build>=0.11.3,<0.12`). Local uv is now 0.12.5; CI was still pinned to 0.12.4.

This PR is also a live check of the GitHub Actions workflow that landed on `main` earlier today.

## What changed

- Raised runtime and dev lower bounds to the latest resolvable versions (lockfile package versions unchanged).
- Bumped `build-system.requires` to `uv_build>=0.12.5,<0.13` so uv 0.12.5 can use its bundled backend.
- Pinned CI `astral-sh/setup-uv` to `0.12.5`.

## Checks

- `uv lock --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest` — 57 passed locally
