### PR TITLE
Render summary table with one row per card and a column per agency purse

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v202608.19.3, 2026-08-19 card summary table uses one row per card with a column per purse; parse agency purses from purseList instead of hardcoding bartPurse
 v202608.19.2, 2026-08-19 replace requests/urllib3 with httpx; stop advertising br/zstd Accept-Encoding without decoders installed; keep httpx per-request logs behind --debug; release with uv build/uv publish instead of twine; add gated release workflow; code health: fix pass-expiry crash on missing endDateTime, drop dead parsers and print_summary, NamedTuple models, pathlib config handling, lazy logging, exclude dev helper from wheel
 v202608.19.1, 2026-08-19 add opt-in macOS Keychain storage for credentials and cookies, with config-file defaults
 v202604.5.1, 2026-04-05 drop Python 3.9/3.10 support and switch CLI table rendering to rich

--- a/README.md
+++ b/README.md
@@ -63,28 +63,25 @@ You also get a super convenient command line binary ``clippercard``::
 ```sh
 $ clippercard -h # see usage information
 $ clippercard summary
-+------------------------------------------------------+
-|            name | Golden Gate Rider                  |
-|           email | goldengate-rider@example.com       |
-| mailing_address | 1 Main St, San Francisco, CA 94105 |
-|           phone | 415-555-5555                       |
-|       alt_phone | 650-555-5555                       |
-| primary_payment | Mastercard ending in 1234          |
-|  backup_payment | Amex ending in 9876                |
-+------------------------------------------------------+
-+---------------------------------------------------------------------------------------+
-| # | Name                      | Serial     | Type  | Status | Products                |
-|---+---------------------------+------------+-------+--------+-------------------------|
-| 1 | Primary, card #2021234134 | 2021234134 | ADULT | Active | Cash Value: $195.00     |
-|   |                           |            |       |        | Current Passes: None    |
-|   |                           |            |       |        | Pending Passes: None    |
-|   |                           |            |       |        | Reload: $255 - Autoload |
-| 2 | Backup, card #2021234156  | 2021234156 | ADULT | Active | Cash Value: $200.00     |
-|   |                           |            |       |        | Current Passes: None    |
-|   |                           |            |       |        | Pending Passes: None    |
-|   |                           |            |       |        | Reload: $200 - Autoload |
-+---------------------------------------------------------------------------------------+
++---------------------------------------------+
+|            name | Go*** Ga*** Ri***         |
+|           email | g***@example.com          |
+| mailing_address | ***                       |
+|           phone | 415-***-***-5555          |
+|       alt_phone | 650-***-***-5555          |
+| primary_payment | Mastercard ending in 1234 |
+|  backup_payment | Amex ending in 9876       |
++---------------------------------------------+
++----------------------------------------------------------------+
+| # | Name    | Serial     | Type  | Status | Cash Value | BART  |
+|---+---------+------------+-------+--------+------------+-------|
+| 1 | Primary | ******4134 | Adult | Active |     $40.00 |       |
+| 2 | Phone   | ******4156 | Adult | Active |    $244.55 | $1.10 |
+| 3 | Watch   | ******4178 | Adult | Active |    $165.40 | $1.40 |
++----------------------------------------------------------------+
 ```
+
+Name, email, address, phone, and card serials are redacted by default. Each stored-value purse (Cash Value, BART, or another agency) gets its own column. Pass `--show-private` to print unredacted details.
 
 If you wish to use clippercard without specifying username/password on the CLI, create a file ``~/.config/clippercard/credentials.ini`` with this format::
 
@@ -200,26 +197,30 @@ $ clippercard summary --output json
 {
   "profile": {
     "name": "Go*** Ga*** Ri***",
-    "email": "g***@example.com"
+    "email": "g***@example.com",
+    "mailing_address": "***",
+    "phone": "415-***-***-5555",
+    "alt_phone": "650-***-***-5555",
+    "primary_payment": "Mastercard ending in 1234",
+    "backup_payment": "Amex ending in 9876"
   },
   "cards": [
     {
-      "serial_number": "******4134",
-      "nickname": "Primary, card ending in 4134",
-      "type": "ADULT",
+      "serial_number": "******4156",
+      "nickname": "Phone",
+      "type": "Adult",
       "status": "Active",
       "products": [
         {
           "name": "Cash Value",
-          "value": "$195.00"
+          "value": "$244.55"
+        },
+        {
+          "name": "BART",
+          "value": "$1.10"
         }
       ],
-      "features": [
-        {
-          "name": "Reload",
-          "value": "$255 - Autoload"
-        }
-      ]
+      "features": []
     }
   ]
 }
@@ -250,7 +251,7 @@ If you'd like to contribute one:
 1. Log in at https://www.clippercard.com and open the dashboard.
 2. View the page source (paste `view-source:https://www.clippercard.com/dashboard` into your browser's address bar) and save the full page.
 3. Redact personal details: name, email, mailing address, phone numbers, and all but the last 4 digits of card serial numbers.
-4. Open a GitHub issue describing what your account has (passes, autoload, BART purse, virtual/phone cards, etc.) — without attaching the file — and the maintainer will arrange a private handoff.
+4. Open a GitHub issue describing what your account has (passes, autoload, BART or other agency purses, virtual/phone cards, etc.) — without attaching the file — and the maintainer will arrange a private handoff.
 
 Please don't paste page source into a public issue or pull request. Even redacted, treat it like a bank statement.
 

--- a/clippercard/parser.py
+++ b/clippercard/parser.py
@@ -196,11 +196,42 @@ def _cents_to_dollars(cents):
     return f"${dollars:.2f}"
 
 
+def _purse_display_name(purse):
+    if purse.get("purseRestriction") == "Unrestricted":
+        return "Cash Value"
+    for candidate in (purse.get("description"), purse.get("purseName")):
+        if candidate:
+            return re.sub(r"\s+HVD Purse$", "", candidate).strip() or candidate
+    return "Purse"
+
+
+def _product_from_purse(purse):
+    if not purse or purse.get("balance") is None:
+        return None
+    return CardProduct(name=_purse_display_name(purse), value=_cents_to_dollars(purse["balance"]))
+
+
+def _products_from_purses(account):
+    """Operator-restricted purses (BART, Muni, ...) live in purseList, not bartPurse-only."""
+    purse_list = account.get("purseList")
+    if purse_list:
+        return [product for purse in purse_list if (product := _product_from_purse(purse))]
+
+    products = []
+    cash_purse = account.get("cashPurse")
+    if cash_purse and cash_purse.get("balance") is not None:
+        products.append(CardProduct(name="Cash Value", value=_cents_to_dollars(cash_purse["balance"])))
+    bart_purse = account.get("bartPurse")
+    if bart_purse and bart_purse.get("balance") is not None:
+        products.append(CardProduct(name="BART", value=_cents_to_dollars(bart_purse["balance"])))
+    return products
+
+
 def parse_dashboard_cards(dashboard_html_content):
     """Parse card data from dashboard page (contains JSON object with card info)
 
     The dashboard page embeds a JavaScript variable with patron account details
-    containing card nicknames, cash values, and BART purse balances.
+    containing card nicknames, cash values, and agency purse balances.
     """
     soup = bs4.BeautifulSoup(dashboard_html_content, "html.parser")
 
@@ -239,22 +270,7 @@ def parse_dashboard_cards(dashboard_html_content):
         nickname = account.get("nickname", "Unknown")
         serial_number = account.get("subsystemAccountReference", "")
 
-        # Extract products (purses with balances)
-        products = []
-
-        # Cash Value purse
-        cash_purse = account.get("cashPurse")
-        if cash_purse:
-            balance = cash_purse.get("balance")
-            if balance is not None:
-                products.append(CardProduct(name="Cash Value", value=_cents_to_dollars(balance)))
-
-        # BART purse
-        bart_purse = account.get("bartPurse")
-        if bart_purse:
-            balance = bart_purse.get("balance")
-            if balance is not None:
-                products.append(CardProduct(name="BART", value=_cents_to_dollars(balance)))
+        products = _products_from_purses(account)
 
         pass_list = account.get("passList", [])
         for pass_info in pass_list:

--- a/clippercard/porcelain.py
+++ b/clippercard/porcelain.py
@@ -29,6 +29,9 @@ from rich.table import Table
 from rich.text import Text
 
 _CONSOLE_WIDTH = 1000
+_CASH_COLUMN = "Cash Value"
+_PASS_COLUMN = "Pass"
+_MONEY_VALUE = re.compile(r"^\$\d+\.\d{2}$")
 
 
 def _render_table(table):
@@ -81,6 +84,70 @@ def _product_to_json(product):
         "name": data.get("name"),
         "value": data.get("value"),
     }
+
+
+def _item_name_value(item):
+    if isinstance(item, str):
+        name, sep, value = item.partition(": ")
+        if not sep:
+            return item, ""
+    else:
+        data = _asdict(item)
+        name = data.get("name")
+        value = data.get("value")
+        if not name:
+            return str(item), ""
+    value = re.sub(r"\s+", " ", str(value).strip()) if value else ""
+    return name, value
+
+
+def _is_money_value(value):
+    return bool(value) and _MONEY_VALUE.fullmatch(value) is not None
+
+
+def _column_names_for_cards(cards):
+    product_names = []
+    feature_names = []
+    seen_products = set()
+    seen_features = set()
+    for card in cards:
+        for item in card.products:
+            name, _ = _item_name_value(item)
+            if name and name not in seen_products:
+                seen_products.add(name)
+                product_names.append(name)
+        for item in card.features:
+            name, _ = _item_name_value(item)
+            if name and name not in seen_products and name not in seen_features:
+                seen_features.add(name)
+                feature_names.append(name)
+    cash = [_CASH_COLUMN] if _CASH_COLUMN in seen_products else []
+    pas = [_PASS_COLUMN] if _PASS_COLUMN in seen_products else []
+    agencies = sorted(
+        (name for name in product_names if name not in {_CASH_COLUMN, _PASS_COLUMN}),
+        key=str.casefold,
+    )
+    return cash + agencies + pas + feature_names
+
+
+def _money_columns(columns, row_values):
+    money = set()
+    for column in columns:
+        cells = [values.get(column, "") for values in row_values]
+        nonempty = [cell for cell in cells if cell]
+        if nonempty and all(_is_money_value(cell) for cell in nonempty):
+            money.add(column)
+    return money
+
+
+def _values_by_column(card):
+    grouped = {}
+    for item in (*card.products, *card.features):
+        name, value = _item_name_value(item)
+        if not name:
+            continue
+        grouped.setdefault(name, []).append(value)
+    return {name: ", ".join(part for part in values if part) for name, values in grouped.items()}
 
 
 def summary_json_output(user_profile, cards, show_private=False):
@@ -137,24 +204,33 @@ def tabular_output(user_profile, cards, show_private=False):
             output_parts.append(_render_table(profile_table))
 
     if cards:
+        columns = _column_names_for_cards(cards)
         card_table = Table(box=box.ASCII)
-        card_table.add_column("#", justify="left", no_wrap=True)
+        card_table.add_column("#", justify="right", no_wrap=True)
         card_table.add_column("Name", justify="left", no_wrap=True)
         card_table.add_column("Serial", justify="left", no_wrap=True)
         card_table.add_column("Type", justify="left", no_wrap=True)
         card_table.add_column("Status", justify="left", no_wrap=True)
-        card_table.add_column("Products", justify="left", no_wrap=True)
+        for column in columns:
+            card_table.add_column(column, no_wrap=True)
+        rows = []
         for i, card in enumerate(cards, 1):
             serial = card.serial_number
             if not show_private:
                 serial = _redact_private_info("serial_number", serial)
+            rows.append((i, card, serial, _values_by_column(card)))
+        money_columns = _money_columns(columns, [values for _, _, _, values in rows])
+        for i, card, serial, values in rows:
             card_table.add_row(
                 str(i),
-                Text(str(card.nickname)),
-                Text(str(serial)),
-                Text(str(card.type)),
-                Text(str(card.status)),
-                Text("\n".join(str(_) for _ in card.products + card.features)),
+                str(card.nickname),
+                str(serial),
+                str(card.type),
+                str(card.status),
+                *[
+                    Text(values.get(column, ""), justify="right") if column in money_columns else values.get(column, "")
+                    for column in columns
+                ],
             )
         output_parts.append(_render_table(card_table))
     elif cards is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "clippercard"
-version = "202608.19.2"
+version = "202608.19.3"
 description = "Unofficial Python API for Clipper Card (transportation pass used in the SF Bay Area)"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_dashboard_parser.py
+++ b/tests/test_dashboard_parser.py
@@ -89,6 +89,61 @@ class TestDashboardCardParsing:
         assert result[0].type == "Adult"
         assert result[1].type == "Adult"
 
+    def test_products_from_purses_includes_other_agencies(self):
+        account = {
+            "purseList": [
+                {
+                    "balance": 4000,
+                    "purseRestriction": "Unrestricted",
+                    "purseName": "Unrestricted",
+                },
+                {
+                    "balance": 110,
+                    "purseRestriction": "OperatorRestricted",
+                    "description": "BART",
+                    "purseName": "BART HVD Purse",
+                },
+                {
+                    "balance": 525,
+                    "purseRestriction": "OperatorRestricted",
+                    "description": "Muni",
+                    "purseName": "Muni HVD Purse",
+                },
+            ]
+        }
+
+        products = parser._products_from_purses(account)
+
+        assert [(product.name, product.value) for product in products] == [
+            ("Cash Value", "$40.00"),
+            ("BART", "$1.10"),
+            ("Muni", "$5.25"),
+        ]
+
+    def test_products_from_purses_falls_back_to_convenience_fields(self):
+        account = {
+            "cashPurse": {"balance": 19500},
+            "bartPurse": {"balance": 110},
+        }
+
+        products = parser._products_from_purses(account)
+
+        assert [(product.name, product.value) for product in products] == [
+            ("Cash Value", "$195.00"),
+            ("BART", "$1.10"),
+        ]
+
+    def test_purse_display_name_strips_hvd_suffix_without_description(self):
+        assert (
+            parser._purse_display_name(
+                {
+                    "purseRestriction": "OperatorRestricted",
+                    "purseName": "Caltrain HVD Purse",
+                }
+            )
+            == "Caltrain"
+        )
+
     def test_all_required_fields(self, dashboard_html):
         """Verify all Card fields are populated"""
         result = parser.parse_dashboard_cards(dashboard_html)

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -30,13 +30,11 @@ def test_tabular_output_renders_profile_and_cards_as_ascii_tables():
 |  name | Golden Gate Hacker        |
 | email | goldengate88@systemfu.com |
 +-----------------------------------+
-+---------------------------------------------------------------------------------------+
-| # | Name                      | Serial     | Type  | Status | Products                |
-|---+---------------------------+------------+-------+--------+-------------------------|
-| 1 | Primary, card #2021234134 | 2021234134 | ADULT | Active | Cash Value: $195.00     |
-|   |                           |            |       |        | Current Passes: None    |
-|   |                           |            |       |        | Reload: $255 - Autoload |
-+---------------------------------------------------------------------------------------+"""
++-------------------------------------------------------------------------------------------------------------+
+| # | Name                      | Serial     | Type  | Status | Cash Value | Current Passes | Reload          |
+|---+---------------------------+------------+-------+--------+------------+----------------+-----------------|
+| 1 | Primary, card #2021234134 | 2021234134 | ADULT | Active |    $195.00 | None           | $255 - Autoload |
++-------------------------------------------------------------------------------------------------------------+"""
     )
 
 
@@ -65,13 +63,11 @@ def test_tabular_output_renders_profile_and_cards_as_ascii_tables_without_privat
 |  name | Go*** Ga*** Ha*** |
 | email | g***@systemfu.com |
 +---------------------------+
-+------------------------------------------------------------------------------------------+
-| # | Name                         | Serial     | Type  | Status | Products                |
-|---+------------------------------+------------+-------+--------+-------------------------|
-| 1 | Primary, card ending in 4134 | ******4134 | ADULT | Active | Cash Value: $195.00     |
-|   |                              |            |       |        | Current Passes: None    |
-|   |                              |            |       |        | Reload: $255 - Autoload |
-+------------------------------------------------------------------------------------------+"""
++----------------------------------------------------------------------------------------------------------------+
+| # | Name                         | Serial     | Type  | Status | Cash Value | Current Passes | Reload          |
+|---+------------------------------+------------+-------+--------+------------+----------------+-----------------|
+| 1 | Primary, card ending in 4134 | ******4134 | ADULT | Active |    $195.00 | None           | $255 - Autoload |
++----------------------------------------------------------------------------------------------------------------+"""
     )
 
 
@@ -88,6 +84,115 @@ def test_tabular_output_redacts_alternate_phone_without_private_info():
 
 def test_tabular_output_reports_missing_cards():
     assert tabular_output(None, []) == "No cards registered"
+
+
+def test_tabular_output_puts_each_product_on_one_row_with_own_column():
+    cards = [
+        SimpleNamespace(
+            nickname="Bridge SF Cute",
+            serial_number="123456788846",
+            type="Adult",
+            status="Active",
+            products=[SimpleNamespace(name="Cash Value", value="$40.00")],
+            features=[],
+        ),
+        SimpleNamespace(
+            nickname="Phone 12 Blue",
+            serial_number="123456788820",
+            type="Adult",
+            status="Active",
+            products=[
+                SimpleNamespace(name="Cash Value", value="$244.55"),
+                SimpleNamespace(name="BART", value="$1.10"),
+            ],
+            features=[],
+        ),
+        SimpleNamespace(
+            nickname="Phone 15",
+            serial_number="123456788937",
+            type="Adult",
+            status="Active",
+            products=[
+                SimpleNamespace(name="Cash Value", value="$237.99"),
+                SimpleNamespace(name="BART", value="$52.15"),
+            ],
+            features=[],
+        ),
+    ]
+
+    output = tabular_output(None, cards, show_private=False)
+
+    assert (
+        output
+        == """+--------------------------------------------------------------------------+
+| # | Name           | Serial       | Type  | Status | Cash Value | BART   |
+|---+----------------+--------------+-------+--------+------------+--------|
+| 1 | Bridge SF Cute | ********8846 | Adult | Active |     $40.00 |        |
+| 2 | Phone 12 Blue  | ********8820 | Adult | Active |    $244.55 |  $1.10 |
+| 3 | Phone 15       | ********8937 | Adult | Active |    $237.99 | $52.15 |
++--------------------------------------------------------------------------+"""
+    )
+
+
+def test_tabular_output_adds_a_money_column_for_each_agency_purse():
+    cards = [
+        SimpleNamespace(
+            nickname="Phone 12 Blue",
+            serial_number="123456788820",
+            type="Adult",
+            status="Active",
+            products=[
+                SimpleNamespace(name="Cash Value", value="$244.55"),
+                SimpleNamespace(name="BART", value="$1.10"),
+            ],
+            features=[],
+        ),
+        SimpleNamespace(
+            nickname="MuniTrain",
+            serial_number="123456788929",
+            type="Adult",
+            status="Active",
+            products=[
+                SimpleNamespace(name="Cash Value", value="$299.60"),
+                SimpleNamespace(name="Muni", value="$12.00"),
+            ],
+            features=[],
+        ),
+    ]
+
+    output = tabular_output(None, cards, show_private=False)
+
+    assert (
+        output
+        == """+---------------------------------------------------------------------------------+
+| # | Name          | Serial       | Type  | Status | Cash Value | BART  | Muni   |
+|---+---------------+--------------+-------+--------+------------+-------+--------|
+| 1 | Phone 12 Blue | ********8820 | Adult | Active |    $244.55 | $1.10 |        |
+| 2 | MuniTrain     | ********8929 | Adult | Active |    $299.60 |       | $12.00 |
++---------------------------------------------------------------------------------+"""
+    )
+
+
+def test_tabular_output_flattens_multiline_pass_values():
+    cards = [
+        SimpleNamespace(
+            nickname="MuniTrain",
+            serial_number="123456788929",
+            type="Adult",
+            status="Active",
+            products=[
+                SimpleNamespace(name="Cash Value", value="$299.60"),
+                SimpleNamespace(name="Pass", value="Muni Monthly\n  - Expires 2026-09-01"),
+            ],
+            features=[],
+        )
+    ]
+
+    output = tabular_output(None, cards, show_private=False)
+
+    assert "\n  - Expires" not in output
+    assert "Muni Monthly - Expires 2026-09-01" in output
+    assert output.count("\n") == 4
 
 
 def test_summary_json_output_renders_profile_and_cards_without_private_info():

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "clippercard"
-version = "202608.19.2"
+version = "202608.19.3"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# PR: card summary table columns + generic agency purses

## Summary

`clippercard summary` table output is one row per card. Each stored-value purse is its own column (Cash Value, BART, Muni, …) instead of stacking `Cash Value:` / `BART:` lines in a single Products cell.

The parser walks `purseList` instead of hardcoding `cashPurse` + `bartPurse`, so a future operator-restricted purse (Muni, Caltrain, …) becomes a product and a table/JSON field without another special case.

Default CLI samples in the README are the redacted (`--show-private` off) form.

## Why

Multiline Products cells wrapped in a narrow terminal and glued adjacent cards onto one line. BART as an allowlisted money column would miss the next agency: the dashboard JSON already represents those as `OperatorRestricted` rows in `purseList`.

## Test plan

- [x] `uv run pytest` (64 tests)
- [x] `uv run ruff check .`
- [ ] Visual: `clippercard summary` on a TTY shows one row per card, BART aligned, serials redacted
